### PR TITLE
Create the log files in UTF-8 encoding instead of the system default

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,6 +7,7 @@
 		<file>${resourcesPath}activity-log_${timestamp}.txt</file>
 		<encoder>
 			<pattern>%msg,%n</pattern>
+			<charset>UTF-8</charset>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
If the character encoding isn't set for logback the log files will be created using the system default as described here https://stackoverflow.com/questions/32207432/logback-default-charset-for-layoutwrappingencoder
and here https://stackoverflow.com/questions/13195037/logback-on-a-mac-returns-question-marks-instead-of-words/13841592#13841592
This leads to the PALA application not recognizing UTF-8 characters as pictured: 
![image](https://github.com/Programming-Activity-Log-Analyser/PALG/assets/92918381/d574ecef-d274-46a1-905f-32f22c8c1f12)
